### PR TITLE
Use EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,11 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.rst]
+indent_size = 4
+indent_style = space


### PR DESCRIPTION
Using [EditorConfig] makes it easier to have consistent styling across
contributors. While CI will (eventually) block changes that don't
conform to some of the required style, the more that can be automated
before getting to CI, the easier it is for someone to contribute.

[editorconfig]: https://editorconfig.org
