### PR TITLE
Add metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,6 +3,7 @@ name = "wishlist"
 version = "0.1.0"
 description = ""
 authors = ["Andy Dirnberger <andy.dirnberger@gmail.com>"]
+license = "MIT"
 
 [tool.poetry.dependencies]
 python = "^3.9"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,6 +5,8 @@ description = ""
 authors = ["Andy Dirnberger <andy.dirnberger@gmail.com>"]
 license = "MIT"
 
+readme = "README.rst"
+
 [tool.poetry.dependencies]
 python = "^3.9"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,8 @@ license = "MIT"
 
 readme = "README.rst"
 
+repository = "https://github.com/dirn/wishlist"
+
 [tool.poetry.dependencies]
 python = "^3.9"
 


### PR DESCRIPTION
A few pieces of information can be added to the `pyproject.toml` file. While I'm
a bit surprised that [Poetry] didn't add the README, the others are definitely
manual steps. One of which, the license, should've been added in 3c45b2a.

[poetry]: https://python-poetry.org
